### PR TITLE
Exit after wp_redirect

### DIFF
--- a/headache.php
+++ b/headache.php
@@ -23,6 +23,7 @@ namespace Headache;
 function disable_feeds(): void
 {
     wp_redirect(home_url());
+    exit;
 }
 
 // Disable feeds.


### PR DESCRIPTION
> Note: [wp_redirect()](https://developer.wordpress.org/reference/functions/wp_redirect/) does not exit automatically, and should almost always be followed by a call to exit;: