### PR TITLE
Strip all HTML tags except those we have whitelisted on paste

### DIFF
--- a/headache.php
+++ b/headache.php
@@ -283,3 +283,27 @@ function disable_indexing()
 }
 
 add_action('pre_option_blog_public', __NAMESPACE__ . '\\disable_indexing');
+
+// Strip all HTML tags except those we have whitelisted
+add_filter('tiny_mce_before_init', function ($in) {
+    $in['paste_preprocess'] = "function(plugin, args) {
+        // Strip all HTML tags except those we have whitelisted
+        var whitelist = 'h1,h2,h3,h4,h5,h6,p,ol,ul,a';
+        var stripped = jQuery('<div>' + args.content + '</div>');
+        var els = stripped.find('*').not(whitelist);
+
+        for (var i = els.length - 1; i >= 0; i--) {
+            var e = els[i];
+            jQuery(e).replaceWith(e.innerHTML);
+        }
+
+        // Strip all class and id attributes
+        stripped.find('*').removeAttr('id').removeAttr('class');
+
+        // Return the clean HTML
+        args.content = stripped.html();
+    }";
+
+    return $in;
+});
+

--- a/headache.php
+++ b/headache.php
@@ -289,7 +289,7 @@ function sanitize_tiny_mce_html_content(array $config): array
 {
     $config['paste_preprocess'] = "function(plugin, args) {
         // Allow specific HTML tags while sanitizing the content
-        const allowedTags = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'ol', 'ul', 'a']);
+        const allowedTags = new Set(['h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'ol', 'ul', 'li', 'a']);
         const sanitizedContent = document.createElement('div');
         sanitizedContent.innerHTML = args.content;
 

--- a/headache.php
+++ b/headache.php
@@ -285,7 +285,8 @@ function disable_indexing()
 add_action('pre_option_blog_public', __NAMESPACE__ . '\\disable_indexing');
 
 // Strip all HTML tags except those we have whitelisted
-add_filter('tiny_mce_before_init', function ($in) {
+function remove_excessive_html_tags($in): array
+{
     $in['paste_preprocess'] = "function(plugin, args) {
         // Strip all HTML tags except those we have whitelisted
         var whitelist = 'h1,h2,h3,h4,h5,h6,p,ol,ul,a';
@@ -305,5 +306,6 @@ add_filter('tiny_mce_before_init', function ($in) {
     }";
 
     return $in;
-});
+}
 
+add_filter('tiny_mce_before_init', remove_excessive_html_tags);


### PR DESCRIPTION
When a user pastes text from another website into the TinyMCE editor, excessive HTML tags are added. This PR removes all HTML tags except those specified in the whitelist.