### PR TITLE
Disable font library

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ All features are activated by default when the plugin is activated.
 - Disable comments feeds
 - Disable feeds
 - Disable attachment pages
+- Disable font library
 - Discourage search engines from indexing in non-production environments
 - Remove contributor, subscriber and author roles
 - Remove Gutenberg's front-end block styles

--- a/headache.php
+++ b/headache.php
@@ -314,3 +314,14 @@ function sanitize_tiny_mce_html_content(array $config): array
 }
 
 add_filter('tiny_mce_before_init', __NAMESPACE__ . '\\sanitize_tiny_mce_html_content');
+
+// Disable the font library.
+// https://developer.wordpress.org/news/snippets/how-to-disable-the-font-library/
+function disable_font_library(array $settings): array
+{
+    $settings['fontLibraryEnabled'] = false;
+
+    return $settings;
+}
+
+add_filter('block_editor_settings_all', __NAMESPACE__ . '\\disable_font_library');


### PR DESCRIPTION
> As a theme author, I often want tight control over typography options to offer users a [curated set of fonts](https://developer.wordpress.org/news/2024/07/22/mixing-and-matching-styles-colors-and-typography-in-wordpress-6-6/) that work well for the theme. One of the first things I do is disable the Font Library in WordPress, ensuring that only the typesets I specifically chose are available to users. This completely disables the user’s ability to upload or manage custom fonts.

https://developer.wordpress.org/news/snippets/how-to-disable-the-font-library/